### PR TITLE
Region flag tab completion

### DIFF
--- a/src/main/java/com/universeguard/UniverseGuard.java
+++ b/src/main/java/com/universeguard/UniverseGuard.java
@@ -54,6 +54,7 @@ import com.universeguard.command.RegionSpawnExecutor;
 import com.universeguard.command.RegionTeleportExecutor;
 import com.universeguard.command.argument.BooleanElement;
 import com.universeguard.command.argument.CommandNameElement;
+import com.universeguard.command.argument.FlagCommandElement;
 import com.universeguard.command.argument.RegionNameElement;
 import com.universeguard.command.argument.SubflagCommandElement;
 import com.universeguard.event.EventListener;
@@ -343,7 +344,7 @@ public class UniverseGuard {
 		
 		CommandSpec regionFlag = CommandSpec.builder().description(Text.of("Set the flag of a region"))
 				.executor(new RegionFlagExecutor())
-				.arguments(new SubflagCommandElement(Text.of("subflag")), GenericArguments.string(Text.of("flag")), new BooleanElement(Text.of("value")))
+				.arguments(new SubflagCommandElement(Text.of("subflag")), new FlagCommandElement(Text.of("flag")), new BooleanElement(Text.of("value")))
 				.permission(RegionPermission.ALL.getValue())
 				.build();
 		

--- a/src/main/java/com/universeguard/command/argument/FlagCommandElement.java
+++ b/src/main/java/com/universeguard/command/argument/FlagCommandElement.java
@@ -6,6 +6,9 @@ import java.util.stream.Collectors;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.PatternMatchingCommandElement;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.text.Text;
@@ -15,7 +18,6 @@ import com.universeguard.region.enums.EnumRegionFlag;
 import com.universeguard.region.enums.EnumRegionInteract;
 import com.universeguard.region.enums.EnumRegionSubflag;
 import com.universeguard.region.enums.EnumRegionVehicle;
-import com.universeguard.utils.LogUtils;
 
 /**
  * This class is used by the Sponge CommandSpec 
@@ -27,14 +29,21 @@ public class FlagCommandElement extends PatternMatchingCommandElement{
 	private EnumRegionSubflag subFlag;
 	public FlagCommandElement(Text key) {
 		super(key);
-		this.subFlag = EnumRegionSubflag.MOBPVE;
 	}
+	
+    public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
+    	try {
+    		String subflag = context.<String>getOne("subflag").get();
+    		this.subFlag = Enum.valueOf(EnumRegionSubflag.class, subflag.toUpperCase());
+		} catch (Exception ex){ 
+			this.subFlag = null; 
+		}
+        super.parse(source, args, context);
+    }
 
 	@Override
 	protected Iterable<String> getChoices(CommandSource source) {
-		LogUtils.print(source.getActiveContexts().toString());
 		//Based on the subFlag variable will return a different list.
-		//I don't know if this can be done, but is worth a try :) 
 		ArrayList<String> flags = new ArrayList<String>();
 		if(this.subFlag != null) {
 			switch(subFlag) {

--- a/src/main/java/com/universeguard/command/argument/SubflagCommandElement.java
+++ b/src/main/java/com/universeguard/command/argument/SubflagCommandElement.java
@@ -31,7 +31,4 @@ public class SubflagCommandElement extends PatternMatchingCommandElement{
 	protected Object getValue(String choice) throws IllegalArgumentException {
 		return choice;
 	}
-	
-
-
 }


### PR DESCRIPTION
You almost had it working.  The parse() method is the key.  From what I could tell, that method gets called on each CommandElement every time the user presses [TAB].  That method gets the CommandContext, so from there we can check to see if the subFlag argument has been set yet, and store its value so that we have it when the getChoices() method gets called.  Works like a charm!